### PR TITLE
Adds missing file types and fixes jpeg handling

### DIFF
--- a/src/db/model/asset.rs
+++ b/src/db/model/asset.rs
@@ -47,11 +47,11 @@ impl FromDbModel<ExportAssetDto> for ExportAsset {
             uuid: model.uuid.clone(),
             dir: model.dir.clone(),
             filename: model.filename.clone(),
-            original_uti: match model.compact_uti {
+            original_uti: match &model.compact_uti {
                 // First one is a fallback for offline libraries as the compact uti is not available
                 // in that case. It should work but is not as accurate as the second one.
                 None => Uti::from_filename(&model.filename),
-                Some(uti) => Uti::from_compact(uti)
+                Some(uti) => Uti::from_compact(uti.as_str())
             }?,
             derivate_uti: Uti::from_name(model.uniform_type_identifier.as_str())?,
             datetime: cocoa::parse_cocoa_timestamp(model.timestamp)?,

--- a/src/db/model/asset.rs
+++ b/src/db/model/asset.rs
@@ -48,10 +48,10 @@ impl FromDbModel<ExportAssetDto> for ExportAsset {
             dir: model.dir.clone(),
             filename: model.filename.clone(),
             original_uti: match &model.compact_uti {
-                // First one is a fallback for offline libraries as the compact uti is not available
+                Some(uti) => Uti::from_compact_and_filename(uti.as_str(), model.filename.as_str()),
+                // Fallback for offline libraries as the compact uti is not available
                 // in that case. It should work but is not as accurate as the second one.
                 None => Uti::from_filename(&model.filename),
-                Some(uti) => Uti::from_compact(uti.as_str())
             }?,
             derivate_uti: Uti::from_name(model.uniform_type_identifier.as_str())?,
             datetime: cocoa::parse_cocoa_timestamp(model.timestamp)?,
@@ -60,8 +60,8 @@ impl FromDbModel<ExportAssetDto> for ExportAsset {
             original_filename: model.original_filename.clone(),
             has_adjustments: model.has_adjustments,
             album: match &model.album {
-                None => None,
                 Some(a) => Some(crate::model::album::Album::from_db_model(a)?),
+                None => None,
             }
         })
     }

--- a/src/db/model/internal_resource.rs
+++ b/src/db/model/internal_resource.rs
@@ -6,5 +6,5 @@ pub struct InternalResource {
     pub id: i32,
     pub fingerprint: String,
     pub local_availability: i32,
-    pub compact_uti: i32,
+    pub compact_uti: String,
 }

--- a/src/db/repo/asset.rs
+++ b/src/db/repo/asset.rs
@@ -60,7 +60,7 @@ pub struct ExportAssetDto {
     pub uuid: String,
     pub dir: String,
     pub filename: String,
-    pub compact_uti: Option<i32>,
+    pub compact_uti: Option<String>,
     pub uniform_type_identifier: String,
     pub timestamp: f32,
     pub favorite: bool,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -301,9 +301,9 @@ diesel::table! {
         /// determined by the file extension.
         ///
         /// - `Photos.db` name: `ZCOMPACTUTI`
-        /// - Type: `INTEGER`
+        /// - Type: `VARCHAR`
         #[sql_name = "ZCOMPACTUTI"]
-        compact_uti -> Integer,
+        compact_uti -> VarChar,
     }
 }
 

--- a/src/model/uti.rs
+++ b/src/model/uti.rs
@@ -23,6 +23,7 @@ const COMPACT_UTI_MOV: &str = "23";
 
 const EXTENSION_HEIC: &str = "heic";
 const EXTENSION_JPEG: &str = "jpeg";
+const EXTENSION_JPG: &str = "jpg";
 const EXTENSION_PNG: &str = "png";
 const EXTENSION_GIF: &str = "gif";
 const EXTENSION_BMP: &str = "bmp";
@@ -36,6 +37,7 @@ const VIDEO_DERIVATE_SUFFIX: &str = "_2_0_a";
 
 static HEIC: Uti = Uti::new(UTI_HEIC, COMPACT_UTI_HEIC, PICTURE_DERIVATE_SUFFIX, EXTENSION_HEIC);
 static JPEG: Uti = Uti::new(UTI_JPEG, COMPACT_UTI_JPEG, PICTURE_DERIVATE_SUFFIX, EXTENSION_JPEG);
+static JPG: Uti = Uti::new(UTI_JPEG, COMPACT_UTI_JPEG, PICTURE_DERIVATE_SUFFIX, EXTENSION_JPG);
 static PNG: Uti = Uti::new(UTI_PNG, COMPACT_UTI_PNG, PICTURE_DERIVATE_SUFFIX, EXTENSION_PNG);
 static GIF: Uti = Uti::new(UTI_GIF, COMPACT_UTI_GIF, PICTURE_DERIVATE_SUFFIX, EXTENSION_GIF);
 static BMP: Uti = Uti::new(UTI_BMP, COMPACT_UTI_BMP, PICTURE_DERIVATE_SUFFIX, EXTENSION_BMP);
@@ -77,26 +79,26 @@ impl Uti {
         }
     }
 
-    pub fn from_compact(compact: &str) -> Result<&'static Uti, String> {
-        match compact {
-            COMPACT_UTI_HEIC => Ok(&HEIC),
-            COMPACT_UTI_JPEG => Ok(&JPEG),
-            COMPACT_UTI_PNG => Ok(&PNG),
-            COMPACT_UTI_GIF => Ok(&GIF),
-            COMPACT_UTI_BMP => Ok(&BMP),
-            COMPACT_UTI_DNG => Ok(&DNG),
-            COMPACT_UTI_RAF => Ok(&RAF),
-            COMPACT_UTI_MP4 => Ok(&MP4),
-            COMPACT_UTI_MOV => Ok(&MOV),
+    pub fn from_compact_and_filename(compact: &str, filename: &str) -> Result<&'static Uti, String> {
+        let extension = Self::extension_from_filename(filename)?;
+
+        match (compact, extension) {
+            (COMPACT_UTI_HEIC, _) => Ok(&HEIC),
+            (COMPACT_UTI_JPEG, EXTENSION_JPEG) => Ok(&JPEG),
+            (COMPACT_UTI_JPEG, EXTENSION_JPG) => Ok(&JPG),
+            (COMPACT_UTI_PNG, _) => Ok(&PNG),
+            (COMPACT_UTI_GIF, _) => Ok(&GIF),
+            (COMPACT_UTI_BMP, _) => Ok(&BMP),
+            (COMPACT_UTI_DNG, _) => Ok(&DNG),
+            (COMPACT_UTI_RAF, _) => Ok(&RAF),
+            (COMPACT_UTI_MP4, _) => Ok(&MP4),
+            (COMPACT_UTI_MOV, _) => Ok(&MOV),
             _ => Err(format!("Unknown compact UTI: {}", compact))
         }
     }
 
     pub fn from_filename(filename: &String) -> Result<&'static Uti, String> {
-        let extension = filename
-            .split('.')
-            .last()
-            .ok_or(format!("File {} seems to have no extension!", filename))?;
+        let extension = Self::extension_from_filename(filename)?;
 
         match extension {
             EXTENSION_HEIC => Ok(&HEIC),
@@ -110,5 +112,12 @@ impl Uti {
             EXTENSION_MOV => Ok(&MOV),
             _ => Err(format!("Unknown extension: {}", extension))
         }
+    }
+
+    fn extension_from_filename(filename: &str) -> Result<&str, String> {
+        filename
+            .split('.')
+            .last()
+            .ok_or(format!("File {} seems to have no extension!", filename))
     }
 }

--- a/src/model/uti.rs
+++ b/src/model/uti.rs
@@ -2,26 +2,32 @@ const UTI_HEIC: &str = "public.heic";
 const UTI_JPEG: &str = "public.jpeg";
 const UTI_PNG: &str = "public.png";
 const UTI_GIF: &str = "com.compuserve.gif";
-const UTI_RAW: &str = "com.adobe.raw-image";
+const UTI_BMP: &str = "com.microsoft.bmp";
+const UTI_DNG: &str = "com.adobe.raw-image";
+const UTI_RAF: &str = "com.fuji.raw-image";
 const UTI_MP4: &str = "public.mpeg-4";
 const UTI_MOV: &str = "com.apple.quicktime-movie";
 
 // Reverse-engineered compact UTIs
 // These are probably some kind of serialized internal representation.
 // In some cases, in the database, we only have these compact UTIs instead of the full UTI
-const COMPACT_UTI_HEIC: i32 = 3;
-const COMPACT_UTI_JPEG: i32 = 1;
-const COMPACT_UTI_PNG: i32 = 6;
-const COMPACT_UTI_GIF: i32 = 7;
-const COMPACT_UTI_RAW: i32 = 9;
-const COMPACT_UTI_MP4: i32 = 24;
-const COMPACT_UTI_MOV: i32 = 23;
+const COMPACT_UTI_HEIC: &str = "3";
+const COMPACT_UTI_JPEG: &str = "1";
+const COMPACT_UTI_PNG: &str = "6";
+const COMPACT_UTI_GIF: &str = "7";
+const COMPACT_UTI_BMP: &str = "_com.microsoft.bmp";
+const COMPACT_UTI_DNG: &str = "9";
+const COMPACT_UTI_RAF: &str = "21";
+const COMPACT_UTI_MP4: &str = "24";
+const COMPACT_UTI_MOV: &str = "23";
 
 const EXTENSION_HEIC: &str = "heic";
 const EXTENSION_JPEG: &str = "jpeg";
 const EXTENSION_PNG: &str = "png";
 const EXTENSION_GIF: &str = "gif";
-const EXTENSION_RAW: &str = "dng";
+const EXTENSION_BMP: &str = "bmp";
+const EXTENSION_DNG: &str = "dng";
+const EXTENSION_RAF: &str = "raf";
 const EXTENSION_MP4: &str = "mp4";
 const EXTENSION_MOV: &str = "mov";
 
@@ -32,21 +38,27 @@ static HEIC: Uti = Uti::new(UTI_HEIC, COMPACT_UTI_HEIC, PICTURE_DERIVATE_SUFFIX,
 static JPEG: Uti = Uti::new(UTI_JPEG, COMPACT_UTI_JPEG, PICTURE_DERIVATE_SUFFIX, EXTENSION_JPEG);
 static PNG: Uti = Uti::new(UTI_PNG, COMPACT_UTI_PNG, PICTURE_DERIVATE_SUFFIX, EXTENSION_PNG);
 static GIF: Uti = Uti::new(UTI_GIF, COMPACT_UTI_GIF, PICTURE_DERIVATE_SUFFIX, EXTENSION_GIF);
-static RAW: Uti = Uti::new(UTI_RAW, COMPACT_UTI_RAW, PICTURE_DERIVATE_SUFFIX, EXTENSION_RAW);
+static BMP: Uti = Uti::new(UTI_BMP, COMPACT_UTI_BMP, PICTURE_DERIVATE_SUFFIX, EXTENSION_BMP);
+static DNG: Uti = Uti::new(UTI_DNG, COMPACT_UTI_DNG, PICTURE_DERIVATE_SUFFIX, EXTENSION_DNG);
+static RAF: Uti = Uti::new(UTI_RAF, COMPACT_UTI_RAF, PICTURE_DERIVATE_SUFFIX, EXTENSION_RAF);
 static MP4: Uti = Uti::new(UTI_MP4, COMPACT_UTI_MP4, VIDEO_DERIVATE_SUFFIX, EXTENSION_MP4);
 static MOV: Uti = Uti::new(UTI_MOV, COMPACT_UTI_MOV, VIDEO_DERIVATE_SUFFIX, EXTENSION_MOV);
 
 #[derive(PartialEq)]
 pub struct Uti {
     pub uti: &'static str,
-    pub compact_uti: i32,
+    pub compact_uti: &'static str,
     pub uuid_suffix: &'static str,
     pub extension: &'static str,
 }
 
 impl Uti {
-    pub const fn new(uti: &'static str, compact_uti: i32, uuid_suffix: &'static str,
-                     extension: &'static str) -> Self {
+    pub const fn new(
+        uti: &'static str,
+        compact_uti: &'static str,
+        uuid_suffix: &'static str,
+        extension: &'static str,
+    ) -> Self {
         Self { uti, compact_uti, uuid_suffix, extension }
     }
 
@@ -56,20 +68,24 @@ impl Uti {
             UTI_JPEG => Ok(&JPEG),
             UTI_PNG => Ok(&PNG),
             UTI_GIF => Ok(&GIF),
-            UTI_RAW => Ok(&RAW),
+            UTI_BMP => Ok(&BMP),
+            UTI_DNG => Ok(&DNG),
+            UTI_RAF => Ok(&RAF),
             UTI_MP4 => Ok(&MP4),
             UTI_MOV => Ok(&MOV),
             _ => Err(format!("Unknown UTI: {}", name))
         }
     }
 
-    pub fn from_compact(compact: i32) -> Result<&'static Uti, String> {
+    pub fn from_compact(compact: &str) -> Result<&'static Uti, String> {
         match compact {
             COMPACT_UTI_HEIC => Ok(&HEIC),
             COMPACT_UTI_JPEG => Ok(&JPEG),
             COMPACT_UTI_PNG => Ok(&PNG),
             COMPACT_UTI_GIF => Ok(&GIF),
-            COMPACT_UTI_RAW => Ok(&RAW),
+            COMPACT_UTI_BMP => Ok(&BMP),
+            COMPACT_UTI_DNG => Ok(&DNG),
+            COMPACT_UTI_RAF => Ok(&RAF),
             COMPACT_UTI_MP4 => Ok(&MP4),
             COMPACT_UTI_MOV => Ok(&MOV),
             _ => Err(format!("Unknown compact UTI: {}", compact))
@@ -87,7 +103,9 @@ impl Uti {
             EXTENSION_JPEG => Ok(&JPEG),
             EXTENSION_PNG => Ok(&PNG),
             EXTENSION_GIF => Ok(&GIF),
-            EXTENSION_RAW => Ok(&RAW),
+            EXTENSION_BMP => Ok(&BMP),
+            EXTENSION_DNG => Ok(&DNG),
+            EXTENSION_RAF => Ok(&RAF),
             EXTENSION_MP4 => Ok(&MP4),
             EXTENSION_MOV => Ok(&MOV),
             _ => Err(format!("Unknown extension: {}", extension))


### PR DESCRIPTION
This PR adds support for `.bmp` and `.raf` files.

Additionally, it aims to fix a bug where JPEGs stored as `.jpg` files internally could not be exported due to the exporter being unable to determine their UTI.

Closes #1 