### PR TITLE
feat: Add additional UTI constants for image and video formats

### DIFF
--- a/src/uti.rs
+++ b/src/uti.rs
@@ -61,10 +61,16 @@ uti_constants! {
     GIF("com.compuserve.gif", "gif", DERIVATE_SUFFIX_IMG),
     DNG("com.adobe.raw-image", "dng", DERIVATE_SUFFIX_IMG),
     RAF("com.fuji.raw-image", "raf", DERIVATE_SUFFIX_IMG),
+    ARW("com.sony.arw-raw-image", "arw", DERIVATE_SUFFIX_IMG),
+    TIFF("public.tiff", "tiff", DERIVATE_SUFFIX_IMG),
+    PSD("com.adobe.photoshop-image", "psd", DERIVATE_SUFFIX_IMG),
     MOV("com.apple.quicktime-movie", "mov", DERIVATE_SUFFIX_VID),
     MP4("public.mpeg-4", "mp4", DERIVATE_SUFFIX_VID),
+    MPEG("public.mpeg", "mpg", DERIVATE_SUFFIX_VID),
+    AVI("public.avi", "avi", DERIVATE_SUFFIX_VID),
     BMP("com.microsoft.bmp", "bmp", DERIVATE_SUFFIX_IMG),
     M4V("com.apple.m4v-video", "m4v", DERIVATE_SUFFIX_VID),
     GPP("public.3gpp", "3gp", DERIVATE_SUFFIX_VID),
-    CR2("com.canon.cr2-raw-image", "cr2", DERIVATE_SUFFIX_IMG)
+    CR2("com.canon.cr2-raw-image", "cr2", DERIVATE_SUFFIX_IMG),
+    GENERIC_CONTENT("public.content", "bin", DERIVATE_SUFFIX_IMG) // For unknown UTIs
 }


### PR DESCRIPTION
Adds support for the following uti constants: com.sony.arw-raw-image, public.tiff, com.adobe.photoshop-image, public.mpeg, public.avi It also adds an generic .bin for the generic public.content constant